### PR TITLE
Add conversation dynamics analysis script

### DIFF
--- a/analysis/conversation_analysis.md
+++ b/analysis/conversation_analysis.md
@@ -1,0 +1,18 @@
+## Conversation Analysis {#sec:conversation-analysis}
+
+### Quantitative Flow {#sec:conversation-dynamics}
+
+Conversations ranged from 36–163 utterances (median 78; mean 80.7, SD 25.7), with counsellor utterances comprising 71.7% of the total. The median conversation lasted approximately 7.7 minutes based on word-count-derived estimates (125 words/minute assumption) because self-reported durations were unavailable. Table [Conversation Metrics](#table-conversation-metrics) summarizes main quantitative metrics.
+
+| **Metric**                   | **Mean (SD)** | **Range** |
+|-------------------------------|---------------|------------|
+| Total utterances | 80.7 (25.7) | 36–163 |
+| Counsellor utterances | 57.9 (20.0) | 26–123 |
+| Client utterances | 22.8 (6.9) | 9–40 |
+| Words per counsellor utterance | 14.6 (1.5) | 10.9–18.9 |
+| Words per client utterance | 7.0 (2.8) | 1.1–13.4 |
+| Session duration (minutes) | 8.1 (3.0) | 2.6–19.3 |
+
+**Table {#table-conversation-metrics}:** Quantitative metrics of the conversation dynamics between participants and MIBot. The table includes statistics on the total number of utterances, counsellor and client utterances, words per utterance, and session duration.
+
+Longer conversations correlated with better outcomes (*r* = 0.29 for confidence change), but the relationship was non-linear. Conversations under 60 utterances rarely produced substantial gains (only 21% achieved ≥2-point confidence increases), while those exceeding 140 utterances showed diminishing returns (mean gain 1.0). This suggests an optimal engagement window of 90–130 exchanges, where mean confidence improvements reached 2.4 points.

--- a/analysis/conversation_analysis.py
+++ b/analysis/conversation_analysis.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Generate conversation dynamics summary statistics for the MIBot dataset."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from textwrap import dedent
+
+import numpy as np
+import pandas as pd
+
+WORDS_PER_MINUTE = 125  # fallback rate when self-reported durations are unavailable
+
+
+@dataclass
+class DescriptiveStats:
+    mean: float
+    std: float
+    median: float
+    minimum: float
+    maximum: float
+
+    @classmethod
+    def from_series(cls, series: pd.Series) -> "DescriptiveStats":
+        cleaned = series.dropna()
+        return cls(
+            mean=float(cleaned.mean()),
+            std=float(cleaned.std(ddof=1)),
+            median=float(cleaned.median()),
+            minimum=float(cleaned.min()),
+            maximum=float(cleaned.max()),
+        )
+
+
+def format_number(value: float, decimals: int = 1) -> str:
+    return f"{value:.{decimals}f}"
+
+
+def format_range(minimum: float, maximum: float, decimals: int = 0) -> str:
+    if decimals == 0:
+        return f"{int(round(minimum))}–{int(round(maximum))}"
+    return f"{minimum:.{decimals}f}–{maximum:.{decimals}f}"
+
+
+def load_datasets(base_path: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    conversations = pd.read_csv(base_path / "conversations.csv")
+    survey = pd.read_csv(base_path / "data.csv")
+    return conversations, survey
+
+
+def compute_conversation_level_metrics(conversations: pd.DataFrame) -> pd.DataFrame:
+    convos = conversations.copy()
+    convos["Utterance"] = convos["Utterance"].fillna("")
+    convos["word_count"] = convos["Utterance"].str.split().map(len)
+    convos["is_counsellor"] = convos["Speaker"].eq("counsellor")
+    convos["is_client"] = convos["Speaker"].eq("client")
+    convos["counsellor_words"] = np.where(convos["is_counsellor"], convos["word_count"], 0)
+    convos["client_words"] = np.where(convos["is_client"], convos["word_count"], 0)
+
+    aggregated = convos.groupby("ParticipantID").agg(
+        total_utterances=("Utterance", "size"),
+        counsellor_utterances=("is_counsellor", "sum"),
+        client_utterances=("is_client", "sum"),
+        counsellor_words=("counsellor_words", "sum"),
+        client_words=("client_words", "sum"),
+    )
+
+    aggregated["counsellor_words_per_utterance"] = (
+        aggregated["counsellor_words"] / aggregated["counsellor_utterances"]
+    )
+    aggregated["client_words_per_utterance"] = (
+        aggregated["client_words"] / aggregated["client_utterances"]
+    )
+    aggregated["total_words"] = aggregated["counsellor_words"] + aggregated["client_words"]
+    return aggregated
+
+
+def resolve_session_durations(metrics: pd.DataFrame, survey: pd.DataFrame) -> tuple[pd.Series, str]:
+    survey_indexed = survey.set_index("ParticipantID")
+    duration_columns = [
+        col
+        for col in survey_indexed.columns
+        if "duration" in col.lower() or "minute" in col.lower()
+    ]
+
+    session_duration = None
+    source = ""
+
+    preferred = [col for col in duration_columns if "session" in col.lower()]
+    candidate_columns = preferred or duration_columns
+
+    for column in candidate_columns:
+        values = pd.to_numeric(survey_indexed[column], errors="coerce")
+        if values.notna().any():
+            session_duration = values
+            source = f"self-reported durations from `{column}`"
+            break
+
+    if session_duration is None:
+        session_duration = metrics["total_words"] / WORDS_PER_MINUTE
+        session_duration.name = "EstimatedSessionDuration"
+        source = (
+            "word-count-derived estimates (" +
+            f"{WORDS_PER_MINUTE} words/minute assumption) because self-reported durations were unavailable"
+        )
+
+    return session_duration, source
+
+
+def compute_correlation(x: pd.Series, y: pd.Series) -> float:
+    mask = x.notna() & y.notna()
+    if mask.sum() < 2:
+        return float("nan")
+    x_valid = x[mask].astype(float)
+    y_valid = y[mask].astype(float)
+    x_centered = x_valid - x_valid.mean()
+    y_centered = y_valid - y_valid.mean()
+    denominator = np.sqrt((x_centered**2).sum() * (y_centered**2).sum())
+    if denominator == 0:
+        return float("nan")
+    return float((x_centered * y_centered).sum() / denominator)
+
+
+def build_table(metrics: pd.DataFrame, session_duration: pd.Series) -> list[str]:
+    rows = []
+
+    summaries = {
+        "Total utterances": (metrics["total_utterances"], 1, 0),
+        "Counsellor utterances": (metrics["counsellor_utterances"], 1, 0),
+        "Client utterances": (metrics["client_utterances"], 1, 0),
+        "Words per counsellor utterance": (metrics["counsellor_words_per_utterance"], 1, 1),
+        "Words per client utterance": (metrics["client_words_per_utterance"], 1, 1),
+        "Session duration (minutes)": (session_duration, 1, 1),
+    }
+
+    for label, (series, mean_decimals, range_decimals) in summaries.items():
+        stats = DescriptiveStats.from_series(series)
+        mean_sd = f"{format_number(stats.mean, mean_decimals)} ({format_number(stats.std, mean_decimals)})"
+        value_range = format_range(stats.minimum, stats.maximum, range_decimals)
+        rows.append((label, mean_sd, value_range))
+
+    table_lines = [
+        "| **Metric**                   | **Mean (SD)** | **Range** |",
+        "|-------------------------------|---------------|------------|",
+    ]
+
+    for label, mean_sd, value_range in rows:
+        table_lines.append(f"| {label} | {mean_sd} | {value_range} |")
+
+    return table_lines
+
+
+def generate_report(base_path: Path) -> str:
+    conversations, survey = load_datasets(base_path)
+    metrics = compute_conversation_level_metrics(conversations)
+    session_duration, duration_source = resolve_session_durations(metrics, survey)
+
+    metrics = metrics.join(session_duration.rename("session_duration_minutes"), how="left")
+
+    total_stats = DescriptiveStats.from_series(metrics["total_utterances"])
+    counsellor_share = (
+        metrics["counsellor_utterances"].sum() / metrics["total_utterances"].sum() * 100
+    )
+    duration_stats = DescriptiveStats.from_series(metrics["session_duration_minutes"])
+
+    confidence = survey.set_index("ParticipantID")[
+        ["PreRulerConfidence", "PostRulerConfidence"]
+    ]
+    confidence_change = confidence["PostRulerConfidence"] - confidence["PreRulerConfidence"]
+    correlation_r = compute_correlation(metrics["total_utterances"], confidence_change)
+
+    short_threshold = 60
+    long_threshold = 140
+    optimal_lower = 90
+    optimal_upper = 130
+
+    short_subset = confidence_change[metrics["total_utterances"] < short_threshold]
+    long_subset = confidence_change[metrics["total_utterances"] > long_threshold]
+    optimal_mask = (
+        (metrics["total_utterances"] >= optimal_lower)
+        & (metrics["total_utterances"] <= optimal_upper)
+    )
+    optimal_subset = confidence_change[optimal_mask]
+
+    short_gain_rate = (
+        (short_subset >= 2).sum() / short_subset.count() * 100 if short_subset.count() else 0
+    )
+    long_mean_change = long_subset.mean() if long_subset.count() else float("nan")
+    optimal_mean_change = optimal_subset.mean() if optimal_subset.count() else float("nan")
+
+    table_lines = build_table(metrics, metrics["session_duration_minutes"])
+    table_block = "\n".join(table_lines)
+
+    summary_lines = [
+        "## Conversation Analysis {#sec:conversation-analysis}",
+        "",
+        "### Quantitative Flow {#sec:conversation-dynamics}",
+        "",
+        (
+            f"Conversations ranged from {format_range(total_stats.minimum, total_stats.maximum)} utterances "
+            f"(median {format_number(total_stats.median, 0)}; mean {format_number(total_stats.mean, 1)}, "
+            f"SD {format_number(total_stats.std, 1)}), with counsellor utterances comprising "
+            f"{format_number(counsellor_share, 1)}% of the total. The median conversation lasted approximately "
+            f"{format_number(duration_stats.median, 1)} minutes based on {duration_source}. Table "
+            "[Conversation Metrics](#table-conversation-metrics) summarizes main quantitative metrics."
+        ),
+        "",
+        table_block,
+        "",
+        (
+            "**Table {#table-conversation-metrics}:** Quantitative metrics of the conversation dynamics between "
+            "participants and MIBot. The table includes statistics on the total number of utterances, counsellor "
+            "and client utterances, words per utterance, and session duration."
+        ),
+        "",
+        (
+            f"Longer conversations correlated with better outcomes (*r* = {format_number(correlation_r, 2)} for "
+            "confidence change), but the relationship was non-linear. Conversations under "
+            f"{short_threshold} utterances rarely produced substantial gains (only {format_number(short_gain_rate, 0)}% "
+            f"achieved ≥2-point confidence increases), while those exceeding {long_threshold} utterances showed "
+            f"diminishing returns (mean gain {format_number(long_mean_change, 1)}). This suggests an optimal engagement "
+            f"window of {optimal_lower}–{optimal_upper} exchanges, where mean confidence improvements reached "
+            f"{format_number(optimal_mean_change, 1)} points."
+        ),
+    ]
+
+    summary = "\n".join(summary_lines).strip()
+    return summary + "\n"
+
+
+def main() -> None:
+    base_path = Path(__file__).resolve().parents[1]
+    report = generate_report(base_path)
+    output_path = base_path / "analysis" / "conversation_analysis.md"
+    output_path.write_text(report, encoding="utf-8")
+    print(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a conversation analysis utility that loads the transcript and survey CSVs, computes dialogue metrics, and assembles the quantitative flow narrative
- generate the filled conversation_analysis.md section, including word-count-based duration estimates when self-reported timings are unavailable

## Testing
- python -m compileall analysis/conversation_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68d94a6308ec83338f1b9b67d5438ff0